### PR TITLE
fix: accept a dialog language at the distance threshold

### DIFF
--- a/ovos_transcription_validator/__init__.py
+++ b/ovos_transcription_validator/__init__.py
@@ -15,6 +15,11 @@ from ovos_utils.lang import standardize_lang_tag
 from ovos_utils.list_utils import deduplicate_list, flatten_list
 from ovos_utils.log import LOG
 
+# The largest language distance that still counts as a usable match. langcodes
+# gives exactly 10 to a specific language measured against its more-commonly-used
+# macrolanguage tag, such as "arz" against "ar", so the bound is inclusive.
+MAX_LANG_DISTANCE = 10
+
 # Default prompt for LLM validation
 # This is formatted as a system message for OpenAI-compatible APIs,
 # and will be combined with a user message for the actual query.
@@ -147,9 +152,10 @@ class TranscriptionValidatorPlugin(UtteranceTransformer):
                 min_distance = distance
                 best_match_lang = available_lang
 
-        # A low score (e.g., < 10) indicates a close language match.
-        # Adjust this threshold if needed.
-        if best_match_lang and min_distance < 10:
+        # A distance of MAX_LANG_DISTANCE or less is a usable match; the
+        # bound is inclusive, because langcodes gives exactly 10 to a language
+        # measured against its macrolanguage tag.
+        if best_match_lang and min_distance <= MAX_LANG_DISTANCE:
             dialogs = self.dialogs[name].get(best_match_lang)
             if dialogs:
                 return random.choice(dialogs)

--- a/test/test_lang_distance_boundary.py
+++ b/test/test_lang_distance_boundary.py
@@ -1,0 +1,36 @@
+"""The language-distance boundary used to pick a dialog language."""
+import unittest
+
+from ovos_transcription_validator import TranscriptionValidatorPlugin
+
+MACROLANGUAGE_PAIRS = [("arz", "ar"), ("wuu", "zh")]
+REGIONAL_PAIRS = [("ar-SA", "ar"), ("en-AU", "en-GB"), ("pt-BR", "pt-PT")]
+UNRELATED_PAIRS = [("en", "zh"), ("es", "fr"), ("fr-CH", "de-CH"), ("af", "nl")]
+
+
+def _dialog(requested: str, available: str):
+    plugin = TranscriptionValidatorPlugin.__new__(TranscriptionValidatorPlugin)
+    plugin.dialogs = {"say_again": {available: ["please repeat"]}}
+    return TranscriptionValidatorPlugin.get_dialog(plugin, "say_again", requested)
+
+
+class TestGetDialogLangBoundary(unittest.TestCase):
+
+    def test_macrolanguage_dialog_is_used(self):
+        for member, macro in MACROLANGUAGE_PAIRS:
+            with self.subTest(member=member):
+                self.assertEqual(_dialog(member, macro), "please repeat")
+
+    def test_regional_dialog_is_used(self):
+        for requested, available in REGIONAL_PAIRS:
+            with self.subTest(requested=requested):
+                self.assertEqual(_dialog(requested, available), "please repeat")
+
+    def test_unrelated_dialog_is_not_used(self):
+        for requested, available in UNRELATED_PAIRS:
+            with self.subTest(requested=requested):
+                self.assertIsNone(_dialog(requested, available))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

## What

`TranscriptionValidatorPlugin.get_dialog` picked the nearest available dialog
language and then required `min_distance < 10`. The bound is now inclusive, and
the literal is replaced by a named module constant, `MAX_LANG_DISTANCE`.

## Why

`langcodes.tag_distance` documents that a distance of exactly 10 is what a
specific language scores against its more-commonly-used macrolanguage tag:
`tag_distance('arz', 'ar')` and `tag_distance('wuu', 'zh')` are both 10.
`langcodes.closest_match` filters with `distance <= max_distance` for the same
reason. The exclusive comparison here rejected precisely the case the number
10 names.

## Behaviour change

A `say_again` (or any other) dialog shipped for a macrolanguage is now spoken
to a speaker of a member language. A session in `arz` gets the `ar` dialog
instead of silence; a session in `wuu` gets the `zh` dialog. Pairs at distance
11 or more are unaffected, so `af` still gets no `nl` dialog.

## Tests

New file `test/test_lang_distance_boundary.py` pins both sides:

- `arz`/`ar` and `wuu`/`zh` produce the dialog.
- `ar-SA`/`ar`, `en-AU`/`en-GB`, `pt-BR`/`pt-PT` produce the dialog.
- `en`/`zh`, `es`/`fr`, `fr-CH`/`de-CH`, `af`/`nl` produce `None`.

RED, with the `< 10` comparison restored:

```
SUBFAILED(member='arz') ...::TestGetDialogLangBoundary::test_macrolanguage_dialog_is_used
SUBFAILED(member='wuu') ...::TestGetDialogLangBoundary::test_macrolanguage_dialog_is_used
2 failed, 3 passed, 7 subtests passed
```

GREEN: `3 passed, 9 subtests passed`. The repository had no test directory
before this branch, so the isolated run and the in-suite run are the same run.

No `pytest.importorskip` at any level.

## Verified against source

- The `min_distance < 10` gate and the surrounding nearest-language loop —
  read from `origin/dev`.
- `distance <= max_distance` in `langcodes.closest_match`, and the
  `tag_distance` macrolanguage docstring — read from the installed `langcodes`.
- RED and GREEN output — produced by running pytest.

## Dependency

None. This plugin uses `langcodes` directly and does not depend on
`ovos-spec-tools`, so no floor pin changes and this PR does not block on any
other.

## Related

Part of an ecosystem-wide correction of the same off-by-one. The reference
implementation is OpenVoiceOS/ovos-spec-tools#96. This PR is independent of it
and can merge in any order.
